### PR TITLE
Sort by magic properies of object.

### DIFF
--- a/src/SortByFieldExtension.php
+++ b/src/SortByFieldExtension.php
@@ -79,7 +79,7 @@ class SortByFieldExtension extends \Twig_Extension {
     if (is_array($item))
       return array_key_exists($field, $item);
     elseif (is_object($item))
-      return property_exists($item, $field);
+      return isset($item->$field) || property_exists($item, $field);
     else
       return false;
   }

--- a/test/Foo.php
+++ b/test/Foo.php
@@ -7,4 +7,17 @@
 
 class Foo {
   public $name;
+  private $attrs = array();
+
+  public function __isset($name) {
+    return isset($this->attrs[$name]);
+  }
+
+  public function __get($name) {
+    return $this->attrs[$name];
+  }
+
+  public function __set($name, $value) {
+    $this->attrs[$name] = $value;
+  }
 }

--- a/test/SortByFieldExtensionTest.php
+++ b/test/SortByFieldExtensionTest.php
@@ -89,6 +89,34 @@ class SortByFieldExtensionTest extends PHPUnit_Framework_TestCase {
     }
   }
 
+  public function testSortObjectsMagicProperty() {
+    $base = array();
+    $ob1 = new Foo();
+    $ob1->magicName = "Redmine";
+    $base[]=$ob1;
+
+    $ob2 = new Foo();
+    $ob2->magicName = "GitLab";
+    $base[]=$ob2;
+
+    $ob3 = new Foo();
+    $ob3->magicName = "Jenkins";
+    $base[]=$ob3;
+
+    $ob4 = new Foo();
+    $ob4->magicName = "Jenkins";
+    $base[]=$ob4;
+
+    $fact = array('GitLab','Jenkins','Jenkins','Redmine');
+
+    $filter = new SortByFieldExtension();
+    $sorted = $filter->sortByFieldFilter($base,'magicName');
+
+    for ($i = 0; $i < count($fact); $i++){
+      $this->assertEquals($fact[$i], $sorted[$i]->magicName);
+    }
+  }
+
   public function testNonArrayBase() {
     $filter = new SortByFieldExtension();
     $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
Extension can't sort object by properties of object handled by magic methods `__isset()` and `__get()` because for such properties function `property_exists()` returns FALSE.

So I added test by `isset()` to invoke `__isset()` magic method.